### PR TITLE
Fixed call of DefaultScope#beforeChange()

### DIFF
--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
@@ -334,7 +334,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 	}
 
 	private Map<String, Command> changes(SharedGraphNode obj) {
-		if (!_changes.isEmpty()) {
+		if (_changes.isEmpty()) {
 			beforeChange();
 		}
 		return _changes.computeIfAbsent(obj, NEW_MAP);


### PR DESCRIPTION
"beforeChange()" must be called when the changes are empty, i.e. on the first change.